### PR TITLE
Fix crash due to index out of bounds

### DIFF
--- a/MFRC522.py
+++ b/MFRC522.py
@@ -384,8 +384,8 @@ class MFRC522:
                 (backData[0] & 0x0F) == 0x0A):
             status = self.MI_ERR
 
-        print("%s backdata &0x0F == 0x0A %s" % (backLen, backData[0] & 0x0F) )
         if status == self.MI_OK:
+            print("%s backdata &0x0F == 0x0A %s" % (backLen, backData[0] & 0x0F) )
             i = 0
             buf = []
             while i < 16:


### PR DESCRIPTION
backData could be nil because of a status error.
This fix moves the (debug) print statement inside the status == OK check to verify the backData array could be read.

Since there is no option to create issues, I've created a PR directly